### PR TITLE
fix: enhance backend retry logic for OpenAI API policy

### DIFF
--- a/infra/modules/apim/policies/api/openai_api_policy.xml
+++ b/infra/modules/apim/policies/api/openai_api_policy.xml
@@ -29,7 +29,9 @@
         <include-fragment fragment-id="openai-usage-streaming" />
     </inbound>
     <backend>
-      <base />
+        <retry count="2" interval="0" first-fast-retry="true" condition="@(context.Response.StatusCode == 429 || (context.Response.StatusCode == 503 && !context.Response.StatusReason.Contains("Backend pool") && !context.Response.StatusReason.Contains("is temporarily unavailable")))">
+            <forward-request buffer-request-body="true" />
+        </retry>
     </backend>
     <outbound>
         <base />


### PR DESCRIPTION
This pull request includes an important change to the `infra/modules/apim/policies/api/openai_api_policy.xml` file, which enhances the retry logic for backend requests.

Improvements to backend request handling:

* [`infra/modules/apim/policies/api/openai_api_policy.xml`](diffhunk://#diff-344cb9c94df1e00624eb87a743c550a8b474576f2221edd9318c8a6a5b1a4fd0L32-R34): Added a retry policy that retries failed requests up to 2 times with no interval between retries, and performs a fast retry on the first attempt. This policy is applied when the response status code is 429 or 503 (with specific conditions).